### PR TITLE
hiera generic lookup

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,106 +3,104 @@
 #
 # Configures Postfix mail transfer agent
 #
-class postfix::config
-(
-    $serveradmin = 'none',
-    $mailaliases,
-    $generic_mappings,
-    $relayhost,
-    $smtp_username,
-    $smtp_password,
-    $domain_mail_server,
-    $inet_interfaces,
-    $smtp_host_lookup,
-    $allow_ipv4_address,
-    $allow_ipv6_address,
-    $allow_ipv6_netmask
+class postfix::config (
+  $serveradmin = 'none',
+  $mailaliases,
+  $generic_mappings,
+  $relayhost,
+  $smtp_username,
+  $smtp_password,
+  $domain_mail_server,
+  $inet_interfaces,
+  $smtp_host_lookup,
+  $allow_ipv4_address,
+  $allow_ipv6_address,
+  $allow_ipv6_netmask) inherits postfix::params {
+  # Configure SMTP authentication, if requested.
+  if $smtp_username {
+    validate_string($smtp_username)
+    validate_string($smtp_password)
 
-) inherits postfix::params
-{
-
-    # Configure SMTP authentication, if requested.
-    if $smtp_username {
-        validate_string($smtp_username)
-        validate_string($smtp_password)
-
-        file { 'postfix-sasl_passwd':
-            ensure => file,
-            name   => $::postfix::params::sasl_passwd,
-            owner  => $::os::params::adminuser,
-            group  => $::os::params::admingroup,
-            mode   => '0600',
-        }
-
-        file_line { "postfix-${relayhost}-${smtp_username}":
-            ensure  => present,
-            path    => $::postfix::params::sasl_passwd,
-            line    => "${relayhost} ${smtp_username}:${smtp_password}",
-            require => File['postfix-sasl_passwd'],
-            notify  => Exec['postfix-update-sasl_passwd'],
-        }
-
-        exec { 'postfix-update-sasl_passwd':
-            command     => "postmap ${::postfix::params::sasl_passwd}",
-            path        => [ '/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/usr/local/sbin' ],
-            refreshonly => true,
-            user        => $::os::params::adminuser,
-            require     => File_line["postfix-${relayhost}-${smtp_username}"],
-        }
+    file { 'postfix-sasl_passwd':
+      ensure => file,
+      name   => $::postfix::params::sasl_passwd,
+      owner  => $::os::params::adminuser,
+      group  => $::os::params::admingroup,
+      mode   => '0600',
     }
 
-    if ! empty($generic_mappings) {
-
-        $smtp_generic_maps_line = "smtp_generic_maps = ${::postfix::params::smtp_generic_maps}"
-
-        file { 'postfix-generic':
-            ensure => file,
-            name   => $::postfix::params::smtp_generic_maps_file,
-            owner  => $::os::params::adminuser,
-            group  => $::os::params::admingroup,
-            mode   => '0644',
-        }
-
-        exec { 'postfix-postmap-generic':
-            command     => "postmap ${::postfix::params::smtp_generic_maps}",
-            cwd         => '/tmp',
-            path        => ['/usr/sbin', '/usr/local/sbin'],
-            refreshonly => true,
-        }
-
-        create_resources('postfix::generic_mapping', $generic_mappings)
+    file_line { "postfix-${relayhost}-${smtp_username}":
+      ensure  => present,
+      path    => $::postfix::params::sasl_passwd,
+      line    => "${relayhost} ${smtp_username}:${smtp_password}",
+      require => File['postfix-sasl_passwd'],
+      notify  => Exec['postfix-update-sasl_passwd'],
     }
 
-    file { 'postfix-main.cf':
-        ensure  => present,
-        name    => $::postfix::params::main_cf,
-        content => template('postfix/main.cf.erb'),
-        owner   => $::os::params::adminuser,
-        group   => $::os::params::admingroup,
-        mode    => '0644',
-        require => Class['::postfix::install'],
-        notify  => Class['::postfix::service'],
+    exec { 'postfix-update-sasl_passwd':
+      command     => "postmap ${::postfix::params::sasl_passwd}",
+      path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/usr/local/sbin'],
+      refreshonly => true,
+      user        => $::os::params::adminuser,
+      require     => File_line["postfix-${relayhost}-${smtp_username}"],
+    }
+  }
+
+  if !empty($generic_mappings) {
+    $smtp_generic_maps_line = "smtp_generic_maps = ${::postfix::params::smtp_generic_maps}"
+
+    file { 'postfix-generic':
+      ensure => file,
+      name   => $::postfix::params::smtp_generic_maps_file,
+      owner  => $::os::params::adminuser,
+      group  => $::os::params::admingroup,
+      mode   => '0644',
     }
 
-    # Set default values on postfix-mailalias resources and define 
-    # newaliases-command
-    Mailalias <| tag == 'postfix-mailalias' |> {
-        target  => '/etc/aliases',
-        require => Class['postfix::install'],
-        notify  => Exec['postfix-newaliases'],
-    }
-    exec { 'postfix-newaliases':
-        command     => 'newaliases',
-        cwd         => '/tmp',
-        path        => '/usr/bin',
-        refreshonly => true,
+    exec { 'postfix-postmap-generic':
+      command     => "postmap ${::postfix::params::smtp_generic_maps}",
+      cwd         => '/tmp',
+      path        => ['/usr/sbin', '/usr/local/sbin'],
+      refreshonly => true,
     }
 
-    # Create standard mailaliases
-    postfix::mailalias { 'postmaster':             recipient => $::os::params::adminuser, }
-    postfix::mailalias { 'webmaster':              recipient => $::os::params::adminuser, }
-    postfix::mailalias { $::os::params::adminuser: recipient => $serveradmin, }
+    create_resources('postfix::generic_mapping', $generic_mappings)
+  }
+  $options = hiera('postfix::options')
 
-    # Create additional mailaliases
-    create_resources('postfix::mailalias', $mailaliases)
+  file { 'postfix-main.cf':
+    ensure  => present,
+    name    => $::postfix::params::main_cf,
+    content => template('postfix/main.cf.erb'),
+    owner   => $::os::params::adminuser,
+    group   => $::os::params::admingroup,
+    mode    => '0644',
+    require => Class['::postfix::install'],
+    notify  => Class['::postfix::service'],
+  }
+
+  # Set default values on postfix-mailalias resources and define
+  # newaliases-command
+  Mailalias <| tag == 'postfix-mailalias' |> {
+    target  => '/etc/aliases',
+    require => Class['postfix::install'],
+    notify  => Exec['postfix-newaliases'],
+  }
+
+  exec { 'postfix-newaliases':
+    command     => 'newaliases',
+    cwd         => '/tmp',
+    path        => '/usr/bin',
+    refreshonly => true,
+  }
+
+  # Create standard mailaliases
+  postfix::mailalias { 'postmaster': recipient => $::os::params::adminuser, }
+
+  postfix::mailalias { 'webmaster': recipient => $::os::params::adminuser, }
+
+  postfix::mailalias { $::os::params::adminuser: recipient => $serveradmin, }
+
+  # Create additional mailaliases
+  create_resources('postfix::mailalias', $mailaliases)
 }

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -11,12 +11,6 @@ biff = no
 append_dot_mydomain = no
 readme_directory = no
 
-smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
-smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-smtpd_use_tls=yes
-smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
-smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
-
 # Please make sure $::fqdn fact exists. If necessary, add an entry to to 
 # /etc/hosts.
 myhostname = <%= @fqdn %>
@@ -47,3 +41,10 @@ smtp_tls_security_level = encrypt
 smtp_sasl_tls_security_options = noanonymous
 smtp_sasl_password_maps = hash:<%= scope['postfix::params::sasl_passwd'] %>
 <% end -%>
+<% if !@options.empty? -%> 
+# additional options from hiera (postfix::options)"
+<%    @options.each{ |key,value| -%>
+<%= key %> = <%= value %>
+<%   }
+   end
+-%>


### PR DESCRIPTION
Hi there. If stumbled upon your module. Great thing. Its the only one which basically does hiera.

Now, I've added a method to add generic (non-checked) hiera-values to the main.cf file.

You can now use:

```
postfix::options:
  option1: value1
  option2: value2
```

and those will be serialized in main.cf

Also note: I've remove the smtp_tls_ options from the template, since I needed to set those.
