### PR TITLE
Make relay restrictions explicit

### DIFF
--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -39,6 +39,7 @@ mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = <%= @inet_interfaces %>
 
+smtpd_relay_restrictions = permit_mynetworks, reject
 smtpd_client_restrictions = permit_mynetworks, reject
 smtp_host_lookup = <%= @smtp_host_lookup %>
 <% if @smtp_username -%>


### PR DESCRIPTION
This fixes a problem with Ubuntu 18.04 where postfix would refuse to allow
connections from the localhost without going through a socket connection.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>