### PR TITLE
Drop support for very old Debian/Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,12 +29,7 @@ class postfix::params {
             $smtp_generic_maps = "hash:${smtp_generic_maps_file}"
             $command_directory = '/usr/sbin'
             $service_name = 'postfix'
-
-            $daemon_directory = $::lsbdistcodename ? {
-                /(stretch|buster|bionic|focal)/ => '/usr/lib/postfix/sbin',
-                default                         => '/usr/lib/postfix',
-            }
-
+            $daemon_directory = '/usr/lib/postfix/sbin'
         }
         'FreeBSD': {
             $package_name = 'mail/postfix'

--- a/metadata.json
+++ b/metadata.json
@@ -33,14 +33,15 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -50,15 +51,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04",
-        "16.04"
+        "18.04",
+        "20.04",
+        "22.04"
       ]
     }
   ],


### PR DESCRIPTION
While at it, update status of RHEL derivative support